### PR TITLE
Fixing environment issues

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,26 +1,20 @@
 name: interactive-sentinel-2-cookbook-dev
 channels:
-  - pyviz
   - conda-forge
 dependencies:
-  - jupyter-book
-  - jupyterlab
-  - jupyter_server
+  - python
   - pip
-  - python>=3.9
-  - matplotlib
-  - xarray
+  - jupyterlab
   - pandas
+  - xarray
+  - dask
   - hvplot
+  - geoviews
   - panel
   - bokeh
   - jupyter_bokeh
   - planetary-computer
   - pystac-client
-  - geoviews
-  - dask
-  - distributed
   - odc-stac
-  - pydantic < 2
   - pip:
       - sphinx-pythia-theme


### PR DESCRIPTION
Fixes #2 (tested on local machine).

Updated the `environment.yml` file according to the recommendations to (1) use conda-forge whenever possible, and (2) not pin packages if not required. The new file also seems to also fix the `ModuleNotFoundError: No module named 'referencing'` error while starting jupyter lab. 