### PR TITLE
Remove os.cpu_count for choosing number of workers for LocalCluster

### DIFF
--- a/notebooks/data-intake-ms-planetary-computer.ipynb
+++ b/notebooks/data-intake-ms-planetary-computer.ipynb
@@ -91,7 +91,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "cluster = LocalCluster(n_workers=os.cpu_count())\n",
+    "cluster = LocalCluster()\n",
     "client = Client(cluster)\n",
     "client"
    ]

--- a/notebooks/data-intake-ms-planetary-computer.ipynb
+++ b/notebooks/data-intake-ms-planetary-computer.ipynb
@@ -82,7 +82,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Since we will use dask to distribute our computation, we can explicitly create a dask cluster which would allow us to specify the required resources - for instance, how many workers are required, threads per worker, etc. For this recipe, we will create a [`LocalCluster`](https://docs.dask.org/en/stable/deploying-python.html#localcluster) on the machine where the notebook will be running with number of workers equal to the number of cpu-cores of the machine."
+    "Since we will use dask to distribute our computation, we can create a dask cluster and connect to it via a dask client. For this recipe, we will create a [`LocalCluster`](https://docs.dask.org/en/stable/deploying-python.html#localcluster) with default values."
    ]
   },
   {


### PR DESCRIPTION
<!--
Project Pythia has automated review requests. If you are not ready for reviews on this contribution, please
open this Pull Request as a "Draft" by clicking the dropdown on the green "Create Pull Request" button in the
lower right corner here.
-->
Removed `os.cpu_count()` while creating dask LocalCluster, letting it choose the number of workers. Addresses #5.