### PR TITLE
replace stackstac with odc-stac in markdown

### DIFF
--- a/notebooks/data-intake-ms-planetary-computer.ipynb
+++ b/notebooks/data-intake-ms-planetary-computer.ipynb
@@ -165,10 +165,10 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now that we have the ID of the  of interest, we can specify certain filters to narrow down to exactly the data we want to look at. The final visualization in the recipe will look at how the NCAR Mesa Lab, Boulder CO looks like throughout the year as seen from space. To narrow down our search, we will use the following criteria -\n",
+    "Now that we have the ID of the collection of interest, we can specify certain filters to narrow down to exactly the data we want to look at. The final visualization in the recipe will look at how the NCAR Mesa Lab, Boulder CO looks like throughout the year as seen from space. To narrow down our search, we will use the following criteria -\n",
     "- Bounding box: We will limit our spatial extent to the bounding box of the NCAR Mesa Lab region.\n",
     "- Date range: We will look at the year 2022\n",
-    "- : `sentinel-2-l2a` (from previous cell)\n",
+    "- Collection: `sentinel-2-l2a` (from previous cell)\n",
     "- Cloud threshold: Since cloud can block the satellite from making an observation of the ground, we will limit our search to satellite images where the cloud cover is less than a certain threshold, 40% in this case.\n",
     "\n",
     "Feel free to change these filtering paramters to suit your needs when running in an interactive session."
@@ -182,7 +182,7 @@
    "source": [
     "bbox = [-105.283263,39.972809,-105.266569,39.987640] # NCAR, boulder, CO. bbox from http://bboxfinder.com/\n",
     "date_range = \"2022-01-01/2022-12-31\"\n",
-    " = \"sentinel-2-l2a\"                        # full id of \n",
+    "collection = \"sentinel-2-l2a\"                        # full id of collection\n",
     "cloud_thresh = 30"
    ]
   },
@@ -193,13 +193,13 @@
    "outputs": [],
    "source": [
     "search = catalog.search(\n",
-    "    s = sentinel2_s,\n",
+    "    collections = sentinel2_collections,\n",
     "    bbox = bbox,\n",
     "    datetime = date_range,\n",
     "    query={\"eo:cloud_cover\": {\"lt\": cloud_thresh}}\n",
     ")\n",
-    "items = search.item_()\n",
-    "print(f\"Found {len(items)} items in the {}\")"
+    "items = search.item_collection()\n",
+    "print(f\"Found {len(items)} items in the {collection}\")"
    ]
   },
   {
@@ -207,7 +207,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We now have an Item with the data that we need. Let's look at one of the items in the collection and explore what assets it has."
+    "We now have an ItemCollection with the data that we need. Let's look at one of the items in the collection and explore what assets it has."
    ]
   },
   {
@@ -500,7 +500,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.4"
+   "version": "3.12.2"
   }
  },
  "nbformat": 4,

--- a/notebooks/data-intake-ms-planetary-computer.ipynb
+++ b/notebooks/data-intake-ms-planetary-computer.ipynb
@@ -16,7 +16,7 @@
    "source": [
     "## Overview\n",
     "\n",
-    "In this notebook, we will take a look at how to retrieve Sentinel-2 L2A satellite imagery from the [Microsoft Planetary Computer Data Catalog (MSPC)](https://planetarycomputer.microsoft.com/catalog). We will go over how to interact with the Data Catalog, which exposes a [SpatioTemporal Asset Catalog (STAC)](https://stacspec.org/en) interface for querying, searching and retrieving data. We will use the [stackstac](https://stackstac.readthedocs.io/en/latest/) package to load the data lazily, which means data is not *actually* read unless required (say, for plotting). Once loaded, we will process the data and make a simple interactive dashboard to look at the satellite imagery over a location for different seasons. We will use the [HoloViz ecosystem](https://holoviz.org/background.html) for the interactive dashboard."
+    "In this notebook, we will take a look at how to retrieve Sentinel-2 L2A satellite imagery from the [Microsoft Planetary Computer Data Catalog (MSPC)](https://planetarycomputer.microsoft.com/catalog). We will go over how to interact with the Data Catalog, which exposes a [SpatioTemporal Asset Catalog (STAC)](https://stacspec.org/en) interface for querying, searching and retrieving data. We will use the [odc-stac](https://odc-stac.readthedocs.io/en/latest/) package to load the data lazily, which means data is not *actually* read unless required (say, for plotting). Once loaded, we will process the data and make a simple interactive dashboard to look at the satellite imagery over a location for different seasons. We will use the [HoloViz ecosystem](https://holoviz.org/background.html) for the interactive dashboard."
    ]
   },
   {
@@ -165,10 +165,10 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now that we have the ID of the collection of interest, we can specify certain filters to narrow down to exactly the data we want to look at. The final visualization in the recipe will look at how the NCAR Mesa Lab, Boulder CO looks like throughout the year as seen from space. To narrow down our search, we will use the following criteria -\n",
+    "Now that we have the ID of the  of interest, we can specify certain filters to narrow down to exactly the data we want to look at. The final visualization in the recipe will look at how the NCAR Mesa Lab, Boulder CO looks like throughout the year as seen from space. To narrow down our search, we will use the following criteria -\n",
     "- Bounding box: We will limit our spatial extent to the bounding box of the NCAR Mesa Lab region.\n",
     "- Date range: We will look at the year 2022\n",
-    "- Collection: `sentinel-2-l2a` (from previous cell)\n",
+    "- : `sentinel-2-l2a` (from previous cell)\n",
     "- Cloud threshold: Since cloud can block the satellite from making an observation of the ground, we will limit our search to satellite images where the cloud cover is less than a certain threshold, 40% in this case.\n",
     "\n",
     "Feel free to change these filtering paramters to suit your needs when running in an interactive session."
@@ -182,7 +182,7 @@
    "source": [
     "bbox = [-105.283263,39.972809,-105.266569,39.987640] # NCAR, boulder, CO. bbox from http://bboxfinder.com/\n",
     "date_range = \"2022-01-01/2022-12-31\"\n",
-    "collection = \"sentinel-2-l2a\"                        # full id of collection\n",
+    " = \"sentinel-2-l2a\"                        # full id of \n",
     "cloud_thresh = 30"
    ]
   },
@@ -193,13 +193,13 @@
    "outputs": [],
    "source": [
     "search = catalog.search(\n",
-    "    collections = sentinel2_collections,\n",
+    "    s = sentinel2_s,\n",
     "    bbox = bbox,\n",
     "    datetime = date_range,\n",
     "    query={\"eo:cloud_cover\": {\"lt\": cloud_thresh}}\n",
     ")\n",
-    "items = search.item_collection()\n",
-    "print(f\"Found {len(items)} items in the {collection}\")"
+    "items = search.item_()\n",
+    "print(f\"Found {len(items)} items in the {}\")"
    ]
   },
   {
@@ -207,7 +207,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We now have an ItemCollection with the data that we need. Let's look at one of the items in the collection and explore what assets it has."
+    "We now have an Item with the data that we need. Let's look at one of the items in the collection and explore what assets it has."
    ]
   },
   {


### PR DESCRIPTION
This notebook previously used stackstac to load the data but now uses odc.stac.  This PR just modifies the markdown in the documentation so it agrees with the code. 