### PR TITLE
fix git clone repo command in README for sentinel2 cookbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,10 +47,10 @@ Jupyter](https://foundations.projectpythia.org/foundations/getting-started-jupyt
 If you are interested in running this material locally on your computer, you will need to follow this workflow:
 
 
-1. Clone the `https://github.com/pritamd47/interactive-sentinel-2` repository:
+1. Clone the ` https://github.com/ProjectPythia/interactive-sentinel-2` repository:
 
    ```bash
-    git clone https://github.com/pritamd47/interactive-sentinel-2.git
+    git clone  https://github.com/ProjectPythia/interactive-sentinel-2.git
    ```
 
 1. Move into the `cookbook-example` directory


### PR DESCRIPTION
The git clone command in the readme pointed to a non-pythia repo.  I assume that is incorrect, so fixing here with pythia repo

<!--
Project Pythia has automated review requests. If you are not ready for reviews on this contribution, please
open this Pull Request as a "Draft" by clicking the dropdown on the green "Create Pull Request" button in the
lower right corner here.
-->
